### PR TITLE
Implement CAPI image building

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,8 +16,6 @@ workflows:
           filters:
             tags:
               only: /^v.*/
-            branches:
-              ignore: /.*/
 
   build:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,3 +16,20 @@ workflows:
           filters:
             tags:
               only: /^v.*/
+            branches:
+              ignore: /.*/
+
+  build:
+    jobs:
+      - architect/push-to-docker:
+          context: "architect"
+          name: push-capi-image-builder-to-quay
+          image: "quay.io/giantswarm/capi-image-builder"
+          username_envar: "QUAY_USERNAME"
+          password_envar: "QUAY_PASSWORD"
+          filters:
+            # Trigger the job also on git tag.
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,27 +12,6 @@ This PR:
 
 - adds/changes/removes etc
 
-### Testing
-
-Description on how capi-image-builder can be tested.
-
-- [ ] fresh install works
-  - [ ] AWS
-  - [ ] Azure
-  - [ ] KVM
-- [ ] upgrade from previous version works
-  - [ ] AWS
-  - [ ] Azure
-  - [ ] KVM
-
-#### Other testing
-
-Description of features to additionally test for capi-image-builder installations.
-
-- [ ] check reconciliation of existing resources after upgrading
-- [ ] X still works after upgrade
-- [ ] Y is installed correctly
-
 <!--
 Changelog must always be updated.
 -->

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM k8s.gcr.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.11
+
+USER root
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get update && apt-get install -y qemu qemu-kvm
+
+USER imagebuilder

--- a/helm/capi-image-builder/Chart.yaml
+++ b/helm/capi-image-builder/Chart.yaml
@@ -1,8 +1,7 @@
 apiVersion: v2
 
 name: capi-image-builder
-version: 1 #[[ .Version ]]
-appVersion: 0.0.1
+version: [[ .Version ]]
 
 description: App to handle building of CAPI VM images for various providers
 

--- a/helm/capi-image-builder/Chart.yaml
+++ b/helm/capi-image-builder/Chart.yaml
@@ -1,16 +1,7 @@
 apiVersion: v2
-
 name: capi-image-builder
 version: [[ .Version ]]
-
 description: App to handle building of CAPI VM images for various providers
-
 home: https://github.com/giantswarm/capi-image-builder
-
-# If you have an icon/logo, you should add it to https://github.com/giantswarm/web-assets
-# and set the final URL as a value here and uncomment.
-#icon: https://s.giantswarm.io/app-icons/example-app/1/light.svg
-
 sources:
 - https://github.com/some-org/some-repo
-

--- a/helm/capi-image-builder/Chart.yaml
+++ b/helm/capi-image-builder/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 
 name: capi-image-builder
-version: [[ .Version ]]
+version: 1 #[[ .Version ]]
 appVersion: 0.0.1
 
 description: App to handle building of CAPI VM images for various providers

--- a/helm/capi-image-builder/templates/_helpers.tpl
+++ b/helm/capi-image-builder/templates/_helpers.tpl
@@ -20,8 +20,6 @@ Common labels
 */}}
 {{- define "labels.common" -}}
 {{ include "labels.selector" . }}
-app.kubernetes.io/name: {{ .Values.name }}
-app.kubernetes.io/instance: {{ .Release.Name | quote }}
 app.giantswarm.io/branch: {{ .Chart.Annotations.branch | replace "#" "-" | replace "/" "-" | replace "." "-" | trunc 63 | trimSuffix "-" | quote }}
 app.giantswarm.io/commit: {{ .Chart.Annotations.commit | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service | quote }}

--- a/helm/capi-image-builder/templates/pipelines/capg.yaml
+++ b/helm/capi-image-builder/templates/pipelines/capg.yaml
@@ -39,7 +39,8 @@ spec:
         name: share-capg-images
       runAfter:
         - build-capi-image
-      params:
+      params: []
+      retries: 1
       workspaces:
       - name: credentials
         workspace: credentials

--- a/helm/capi-image-builder/templates/pipelines/capg.yaml
+++ b/helm/capi-image-builder/templates/pipelines/capg.yaml
@@ -10,6 +10,7 @@ spec:
   params:
   - name: KUBERNETES_VERSION
     type: string
+    description: "The Kubernetes version to build for - e.g. 1.24.3 (Note, if a `v` prefix is added, this will be stripped off in the build task)"
   workspaces:
   - name: credentials
     description: "GCP credentials containing the required `sa.json` file for authenticating"

--- a/helm/capi-image-builder/templates/pipelines/capg.yaml
+++ b/helm/capi-image-builder/templates/pipelines/capg.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: build-capg-image
+spec:
+  params:
+  - name: KUBERNETES_VERSION
+    type: string
+  workspaces:
+  - name: credentials
+    description: "GCP credentials containing the required `sa.json` file for authenticating"
+    optional: false
+  tasks:
+    - name: build-capi-image
+      timeout: 6h
+      retries: 1
+      taskRef:
+        name: build-capi-image
+      params:
+        - name: KUBERNETES_VERSION
+          value: $(params.KUBERNETES_VERSION)
+        - name: MAKE_TARGET
+          value: "build-gce-all"
+        - name: ENV_VARS
+          value: |
+            export GCP_PROJECT_ID=giantswarm-vm-images
+            export GOOGLE_APPLICATION_CREDENTIALS=/config/credentials/sa.json
+      workspaces:
+      - name: credentials
+        workspace: credentials
+      - name: output
+        emptyDir: {}
+      - name: vars
+        emptyDir: {}
+
+    - name: share-images
+      taskRef:
+        name: share-capg-images
+      runAfter:
+        - build-capi-image
+      params:
+      workspaces:
+      - name: credentials
+        workspace: credentials

--- a/helm/capi-image-builder/templates/pipelines/capg.yaml
+++ b/helm/capi-image-builder/templates/pipelines/capg.yaml
@@ -2,7 +2,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
-  name: {{ include "name" }}-build-capg-image
+  name: {{ include "name" . }}-build-capg-image
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "labels.common" . | nindent 4 }}
@@ -19,7 +19,7 @@ spec:
       timeout: 6h
       retries: 1
       taskRef:
-        name: {{ include "name" }}-build-capi-image
+        name: {{ include "name" . }}-build-capi-image
       params:
         - name: KUBERNETES_VERSION
           value: $(params.KUBERNETES_VERSION)
@@ -41,7 +41,7 @@ spec:
       taskRef:
         name: share-capg-images
       runAfter:
-        - {{ include "name" }}-build-capi-image
+        - {{ include "name" . }}-build-capi-image
       params: []
       retries: 1
       workspaces:

--- a/helm/capi-image-builder/templates/pipelines/capg.yaml
+++ b/helm/capi-image-builder/templates/pipelines/capg.yaml
@@ -2,7 +2,10 @@
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
-  name: build-capg-image
+  name: {{ include "name" }}-build-capg-image
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
 spec:
   params:
   - name: KUBERNETES_VERSION
@@ -16,7 +19,7 @@ spec:
       timeout: 6h
       retries: 1
       taskRef:
-        name: build-capi-image
+        name: {{ include "name" }}-build-capi-image
       params:
         - name: KUBERNETES_VERSION
           value: $(params.KUBERNETES_VERSION)
@@ -38,7 +41,7 @@ spec:
       taskRef:
         name: share-capg-images
       runAfter:
-        - build-capi-image
+        - {{ include "name" }}-build-capi-image
       params: []
       retries: 1
       workspaces:

--- a/helm/capi-image-builder/templates/pipelines/capo.yaml
+++ b/helm/capi-image-builder/templates/pipelines/capo.yaml
@@ -1,7 +1,10 @@
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
-  name: build-capo-image
+  name: {{ include "name" }}-build-capo-image
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
 spec:
   params:
   - name: KUBERNETES_VERSION
@@ -20,7 +23,7 @@ spec:
       timeout: 6h
       retries: 1
       taskRef:
-        name: build-capi-image
+        name: {{ include "name" }}-build-capi-image
       params:
         - name: KUBERNETES_VERSION
           value: $(params.KUBERNETES_VERSION)
@@ -39,7 +42,7 @@ spec:
 
     - name: upload-images
       taskRef:
-        name: s3-upload-image
+        name: {{ include "name" }}-s3-upload-image
       runAfter:
         - build-capi-image
       retries: 1

--- a/helm/capi-image-builder/templates/pipelines/capo.yaml
+++ b/helm/capi-image-builder/templates/pipelines/capo.yaml
@@ -1,7 +1,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
-  name: {{ include "name" }}-build-capo-image
+  name: {{ include "name" . }}-build-capo-image
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "labels.common" . | nindent 4 }}
@@ -23,7 +23,7 @@ spec:
       timeout: 6h
       retries: 1
       taskRef:
-        name: {{ include "name" }}-build-capi-image
+        name: {{ include "name" . }}-build-capi-image
       params:
         - name: KUBERNETES_VERSION
           value: $(params.KUBERNETES_VERSION)
@@ -42,7 +42,7 @@ spec:
 
     - name: upload-images
       taskRef:
-        name: {{ include "name" }}-s3-upload-image
+        name: {{ include "name" . }}-s3-upload-image
       runAfter:
         - build-capi-image
       retries: 1

--- a/helm/capi-image-builder/templates/pipelines/capo.yaml
+++ b/helm/capi-image-builder/templates/pipelines/capo.yaml
@@ -1,0 +1,48 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: build-capo-image
+spec:
+  params:
+  - name: KUBERNETES_VERSION
+    type: string
+  workspaces:
+  - name: output
+    description: "The location where VM images are saved to"
+    optional: false
+  - name: credentials
+    description: "The AWS S3 credentials and details needed to upload built images to an S3 bucket"
+    optional: false
+  tasks:
+    - name: build-capi-image
+      timeout: 6h
+      retries: 1
+      taskRef:
+        name: build-capi-image
+      params:
+        - name: KUBERNETES_VERSION
+          value: $(params.KUBERNETES_VERSION)
+        - name: MAKE_TARGET
+          value: "build-qemu-ubuntu-2004"
+        - name: PACKER_VARS_FILE
+          value: |
+            {"memory": "4096","cpus": "4","accelerator": "none"}
+      workspaces:
+      - name: credentials
+        workspace: credentials
+      - name: output
+        workspace: output
+      - name: vars
+        emptyDir: {}
+
+    - name: upload-images
+      taskRef:
+        name: s3-upload-image
+      runAfter:
+        - build-capi-image
+      params:
+      workspaces:
+      - name: credentials
+        workspace: credentials
+      - name: source
+        workspace: output

--- a/helm/capi-image-builder/templates/pipelines/capo.yaml
+++ b/helm/capi-image-builder/templates/pipelines/capo.yaml
@@ -17,9 +17,22 @@ spec:
     description: "The AWS S3 credentials and details needed to upload built images to an S3 bucket"
     optional: false
   tasks:
-    # TODO: Add task to check if image already exists
+    - name: check-image-exists
+      taskRef:
+        name: {{ include "name" . }}-s3-image-exists
+      params:
+      - name: IMAGE
+        # We pass the sha256 rather than the image itself so we can check that the process completed (sha is the last setp)
+        value: cluster-api-v$(params.KUBERNETES_VERSION).sha256sums
+      workspaces:
+      - name: credentials
+        workspace: credentials
 
     - name: build-capi-image
+      when:
+      - input: "$(tasks.check-image-exists.results.image-exists)"
+        operator: in
+        values: ["false"]
       timeout: 6h
       retries: 1
       taskRef:

--- a/helm/capi-image-builder/templates/pipelines/capo.yaml
+++ b/helm/capi-image-builder/templates/pipelines/capo.yaml
@@ -14,6 +14,8 @@ spec:
     description: "The AWS S3 credentials and details needed to upload built images to an S3 bucket"
     optional: false
   tasks:
+    # TODO: Add task to check if image already exists
+
     - name: build-capi-image
       timeout: 6h
       retries: 1
@@ -40,7 +42,8 @@ spec:
         name: s3-upload-image
       runAfter:
         - build-capi-image
-      params:
+      retries: 1
+      params: []
       workspaces:
       - name: credentials
         workspace: credentials

--- a/helm/capi-image-builder/templates/pipelines/trigger-capi-builds.yaml
+++ b/helm/capi-image-builder/templates/pipelines/trigger-capi-builds.yaml
@@ -1,7 +1,10 @@
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
-  name: trigger-capi-builds
+  name: {{ include "name" }}-trigger-capi-builds
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
 spec:
   params: []
   workspaces: []
@@ -9,4 +12,4 @@ spec:
   - name: trigger-builds-from-kubernetes-releases
     retries: 1
     taskRef:
-      name: trigger-builds-from-kubernetes-releases
+      name: {{ include "name" }}-trigger-builds-from-kubernetes-releases

--- a/helm/capi-image-builder/templates/pipelines/trigger-capi-builds.yaml
+++ b/helm/capi-image-builder/templates/pipelines/trigger-capi-builds.yaml
@@ -1,0 +1,12 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: trigger-capi-builds
+spec:
+  params: []
+  workspaces: []
+  tasks:
+  - name: trigger-builds-from-kubernetes-releases
+    retries: 1
+    taskRef:
+      name: trigger-builds-from-kubernetes-releases

--- a/helm/capi-image-builder/templates/pipelines/trigger-capi-builds.yaml
+++ b/helm/capi-image-builder/templates/pipelines/trigger-capi-builds.yaml
@@ -1,7 +1,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
-  name: {{ include "name" }}-trigger-capi-builds
+  name: {{ include "name" . }}-trigger-capi-builds
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "labels.common" . | nindent 4 }}
@@ -12,4 +12,4 @@ spec:
   - name: trigger-builds-from-kubernetes-releases
     retries: 1
     taskRef:
-      name: {{ include "name" }}-trigger-builds-from-kubernetes-releases
+      name: {{ include "name" . }}-trigger-builds-from-kubernetes-releases

--- a/helm/capi-image-builder/templates/secrets/aws-credentials.yaml
+++ b/helm/capi-image-builder/templates/secrets/aws-credentials.yaml
@@ -1,7 +1,10 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: aws-credentials
+  name: {{ include "name" }}-aws-credentials
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
 type: Opaque
 stringData:
   credentials: |-

--- a/helm/capi-image-builder/templates/secrets/aws-credentials.yaml
+++ b/helm/capi-image-builder/templates/secrets/aws-credentials.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "name" }}-aws-credentials
+  name: {{ include "name" . }}-aws-credentials
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "labels.common" . | nindent 4 }}

--- a/helm/capi-image-builder/templates/secrets/aws-credentials.yaml
+++ b/helm/capi-image-builder/templates/secrets/aws-credentials.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: aws-credentials
+type: Opaque
+stringData:
+  credentials: |-
+    [default]
+    aws_access_key_id     = {{.Values.s3.accessKeyId}}
+    aws_secret_access_key = {{.Values.s3.secretAccessKey}}
+  config: |-
+    [default]
+    output=json
+  cli-params: --endpoint-url={{.Values.s3.endpointURL}}
+  bucket-name: {{.Values.s3.bucketName}}

--- a/helm/capi-image-builder/templates/secrets/gcp-credentials.yaml
+++ b/helm/capi-image-builder/templates/secrets/gcp-credentials.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: gcp-credentials
+type: Opaque
+stringData:
+  sa.json: {{ .Values.gcp.serviceAccountCredentialsJSON }}

--- a/helm/capi-image-builder/templates/secrets/gcp-credentials.yaml
+++ b/helm/capi-image-builder/templates/secrets/gcp-credentials.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "name" }}-gcp-credentials
+  name: {{ include "name" . }}-gcp-credentials
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "labels.common" . | nindent 4 }}

--- a/helm/capi-image-builder/templates/secrets/gcp-credentials.yaml
+++ b/helm/capi-image-builder/templates/secrets/gcp-credentials.yaml
@@ -1,7 +1,10 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: gcp-credentials
+  name: {{ include "name" }}-gcp-credentials
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
 type: Opaque
 stringData:
   sa.json: {{ .Values.gcp.serviceAccountCredentialsJSON }}

--- a/helm/capi-image-builder/templates/tasks/build-capi-image.yaml
+++ b/helm/capi-image-builder/templates/tasks/build-capi-image.yaml
@@ -13,8 +13,7 @@ spec:
     default: "1.24.1"
   - name: BUILDER_IMAGE
     type: string
-    # TODO: Replace this with our own modified image
-    default: k8s.gcr.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.12
+    default: {{.Values.image.registry}}/{{.Values.image.name}}:{{.Values.image.tag}}
   - name: ENV_VARS
     type: string
     default: ""

--- a/helm/capi-image-builder/templates/tasks/build-capi-image.yaml
+++ b/helm/capi-image-builder/templates/tasks/build-capi-image.yaml
@@ -1,0 +1,77 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: build-capi-image
+spec:
+  params:
+  - name: ACCELERATOR
+    default: none
+  - name: KUBERNETES_VERSION
+    default: "1.24.1"
+  - name: CPUS
+    default: "4"
+  - name: MEMORY
+    default: "4096"
+  - name: build-image
+    default: k8s.gcr.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.12
+  - name: env-vars
+    default: ""
+  - name: make-target
+    default: "build-qemu-ubuntu-2004"
+  workspaces:
+  - name: credentials
+    mountPath: /config/credentials
+    optional: true
+  - name: vars
+    optional: true
+  - name: output
+    optional: true
+  steps:
+    - name: build-vars
+      image: bash:5
+      script: |
+        VERSION_PARTS=($(echo $(params.KUBERNETES_VERSION) | tr "." "\n"))
+        VERSION_MAJOR=${VERSION_PARTS[0]}
+        VERSION_MINOR=${VERSION_PARTS[1]}
+        echo '{
+          "build_timestamp": "gs",
+          "kubernetes_deb_version": "$(params.KUBERNETES_VERSION)-00",
+          "kubernetes_rpm_version": "$(params.KUBERNETES_VERSION)-0",
+          "kubernetes_semver": "v$(params.KUBERNETES_VERSION)",
+          "kubernetes_series": "v${VERSION_MAJOR}.${VERSION_MINOR}",
+          "output_directory": "$(workspaces.output.path)/cluster-api-v$(params.KUBERNETES_VERSION)",
+          "memory": "$(params.MEMORY)",
+          "cpus": "$(params.CPUS)",
+          "accelerator": "$(params.ACCELERATOR)"
+          }' > $(workspaces.vars.path)/vars.json
+
+    - name: build-env-vars
+      image: bash:5
+      script: |
+        echo "$(params.env-vars)" > $(workspaces.vars.path)/env
+
+    - name: build-openstack-image
+      image: $(params.build-image)
+      timeout: 4h
+      resources:
+        requests:
+          memory: 6Gi
+          cpu: 4000m
+      securityContext:
+        privileged: true
+      env:
+      - name: PACKER_VAR_FILES
+        value: $(workspaces.vars.path)/vars.json
+      - name: PACKER_LOG
+        value: "1"
+      script: |
+        source $(workspaces.vars.path)/env
+        make $(params.make-target)
+
+    - name: generate-sha
+      image: bash:5
+      workingDir: $(workspaces.output.path)
+      script: |
+        if [ -f "cluster-api-v$(params.KUBERNETES_VERSION)" ]; then
+          sha256sum cluster-api-v$(params.KUBERNETES_VERSION) > cluster-api-v$(params.KUBERNETES_VERSION).sha256sums
+        fi

--- a/helm/capi-image-builder/templates/tasks/build-capi-image.yaml
+++ b/helm/capi-image-builder/templates/tasks/build-capi-image.yaml
@@ -1,7 +1,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
-  name: {{ include "name" }}-build-capi-image
+  name: {{ include "name" . }}-build-capi-image
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "labels.common" . | nindent 4 }}

--- a/helm/capi-image-builder/templates/tasks/build-capi-image.yaml
+++ b/helm/capi-image-builder/templates/tasks/build-capi-image.yaml
@@ -1,7 +1,10 @@
 apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
-  name: build-capi-image
+  name: {{ include "name" }}-build-capi-image
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
 spec:
   description: "Builds a CAPI VM image based on the provided params. The mechanism used to create the image depends on the MAKE_TARGET chosen."
   params:
@@ -31,7 +34,7 @@ spec:
     optional: false
   steps:
     - name: build-vars
-      image: bash:5
+      image: quay.io/giantswarm/docker-kubectl:1.24.2
       script: |
         VERSION_PARTS=($(echo $(params.KUBERNETES_VERSION) | tr "." "\n"))
         VERSION_MAJOR=${VERSION_PARTS[0]}

--- a/helm/capi-image-builder/templates/tasks/build-capi-image.yaml
+++ b/helm/capi-image-builder/templates/tasks/build-capi-image.yaml
@@ -3,60 +3,68 @@ kind: Task
 metadata:
   name: build-capi-image
 spec:
+  description: "Builds a CAPI VM image based on the provided params. The mechanism used to create the image depends on the MAKE_TARGET chosen."
   params:
-  - name: ACCELERATOR
-    default: none
   - name: KUBERNETES_VERSION
+    type: string
     default: "1.24.1"
-  - name: CPUS
-    default: "4"
-  - name: MEMORY
-    default: "4096"
-  - name: build-image
+  - name: BUILDER_IMAGE
+    type: string
+    # TODO: Replace this with our own modified image
     default: k8s.gcr.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.12
-  - name: env-vars
+  - name: ENV_VARS
+    type: string
     default: ""
-  - name: make-target
-    default: "build-qemu-ubuntu-2004"
+  - name: MAKE_TARGET
+    type: string
+    default: ""
+  - name: PACKER_VARS_FILE
+    type: string
+    default: "{}"
   workspaces:
   - name: credentials
     mountPath: /config/credentials
     optional: true
   - name: vars
-    optional: true
+    optional: false
   - name: output
-    optional: true
+    optional: false
   steps:
     - name: build-vars
       image: bash:5
       script: |
         VERSION_PARTS=($(echo $(params.KUBERNETES_VERSION) | tr "." "\n"))
         VERSION_MAJOR=${VERSION_PARTS[0]}
+        VERSION_MAJOR=${VERSION_MAJOR#v} # Strip any `v` prefix
         VERSION_MINOR=${VERSION_PARTS[1]}
+
         echo '{
           "build_timestamp": "gs",
           "kubernetes_deb_version": "$(params.KUBERNETES_VERSION)-00",
           "kubernetes_rpm_version": "$(params.KUBERNETES_VERSION)-0",
           "kubernetes_semver": "v$(params.KUBERNETES_VERSION)",
           "kubernetes_series": "v${VERSION_MAJOR}.${VERSION_MINOR}",
-          "output_directory": "$(workspaces.output.path)/cluster-api-v$(params.KUBERNETES_VERSION)",
-          "memory": "$(params.MEMORY)",
-          "cpus": "$(params.CPUS)",
-          "accelerator": "$(params.ACCELERATOR)"
-          }' > $(workspaces.vars.path)/vars.json
+          "output_directory": "$(workspaces.output.path)/cluster-api-v$(params.KUBERNETES_VERSION)"
+        }' > default_vars.json
+        echo "Default Packer vars:"
+        cat default_vars.json
+
+        echo '$(params.PACKER_VARS_FILE)' > override_vars.json
+        echo "Override Packer vars:"
+        cat override_vars.json
+
+        jq -s '.[0] * .[1]' default_vars.json override_vars.json > $(workspaces.vars.path)/vars.json
+        echo "Final Packer vars:"
+        cat $(workspaces.vars.path)/vars.json
 
     - name: build-env-vars
       image: bash:5
       script: |
-        echo "$(params.env-vars)" > $(workspaces.vars.path)/env
+        echo "$(params.ENV_VARS)" > $(workspaces.vars.path)/env
 
-    - name: build-openstack-image
-      image: $(params.build-image)
+    - name: build-image
+      image: $(params.BUILDER_IMAGE)
       timeout: 4h
-      resources:
-        requests:
-          memory: 6Gi
-          cpu: 4000m
       securityContext:
         privileged: true
       env:
@@ -66,12 +74,8 @@ spec:
         value: "1"
       script: |
         source $(workspaces.vars.path)/env
-        make $(params.make-target)
-
-    - name: generate-sha
-      image: bash:5
-      workingDir: $(workspaces.output.path)
-      script: |
+        make $(params.MAKE_TARGET)
+        # If a local file has been created (e.g. for CAPO) we'll also generate a sha256 for it
         if [ -f "cluster-api-v$(params.KUBERNETES_VERSION)" ]; then
-          sha256sum cluster-api-v$(params.KUBERNETES_VERSION) > cluster-api-v$(params.KUBERNETES_VERSION).sha256sums
+          sha256sum cluster-api-v$(params.KUBERNETES_VERSION) > $(workspaces.output.path)/cluster-api-v$(params.KUBERNETES_VERSION).sha256sums
         fi

--- a/helm/capi-image-builder/templates/tasks/s3-image-exists.yaml
+++ b/helm/capi-image-builder/templates/tasks/s3-image-exists.yaml
@@ -19,7 +19,7 @@ spec:
     optional: false
   steps:
     - name: does-image-exist
-      image: docker.io/amazon/aws-cli:2.0.52@sha256:1506cec98a7101c935176d440a14302ea528b8f92fcaf4a6f1ea2d7ecef7edc4 #tag: 2.0.52
+      image: {{.Values.s3.image.registry}}/{{.Values.s3.image.name}}:{{.Values.s3.image.tag}}
       script: |
         check_exists() {
           aws s3 $(cat $(workspaces.credentials.path)/cli-params) ls s3://$(cat $(workspaces.credentials.path)/bucket-name)/$(params.IMAGE) &>/dev/null

--- a/helm/capi-image-builder/templates/tasks/s3-image-exists.yaml
+++ b/helm/capi-image-builder/templates/tasks/s3-image-exists.yaml
@@ -1,0 +1,32 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: {{ include "name" . }}-s3-image-exists
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+spec:
+  description: "Checks if an image exists in the S3 bucket"
+  params:
+  - name: IMAGE
+    type: string
+  results:
+  - name: image-exists
+    description: A boolean (string) indicating if the requested image exists in the bucket
+  workspaces:
+  - name: credentials
+    mountPath: /root/.aws
+    optional: false
+  steps:
+    - name: does-image-exist
+      image: docker.io/amazon/aws-cli:2.0.52@sha256:1506cec98a7101c935176d440a14302ea528b8f92fcaf4a6f1ea2d7ecef7edc4 #tag: 2.0.52
+      script: |
+        check_exists() {
+          aws s3 $(cat $(workspaces.credentials.path)/cli-params) ls s3://$(cat $(workspaces.credentials.path)/bucket-name)/$(params.IMAGE) &>/dev/null
+        }
+
+        if check_exists; then
+          echo "true" > $(results.image-exists.path)
+        else
+          echo "false" > $(results.image-exists.path)
+        fi

--- a/helm/capi-image-builder/templates/tasks/s3-upload-image.yaml
+++ b/helm/capi-image-builder/templates/tasks/s3-upload-image.yaml
@@ -21,5 +21,5 @@ spec:
         set -x
         files=($(find $(workspaces.source.path)))
         for file in "${files[@]}"; do
-          aws s3 $(cat$(workspaces.credentials.path)/cli-params) cp ${file} s3://$(cat$(workspaces.credentials.path)/bucket-name)/
+          aws s3 $(cat $(workspaces.credentials.path)/cli-params) cp ${file} s3://$(cat $(workspaces.credentials.path)/bucket-name)/
         done

--- a/helm/capi-image-builder/templates/tasks/s3-upload-image.yaml
+++ b/helm/capi-image-builder/templates/tasks/s3-upload-image.yaml
@@ -1,7 +1,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
-  name: {{ include "name" }}-s3-upload-image
+  name: {{ include "name" . }}-s3-upload-image
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "labels.common" . | nindent 4 }}

--- a/helm/capi-image-builder/templates/tasks/s3-upload-image.yaml
+++ b/helm/capi-image-builder/templates/tasks/s3-upload-image.yaml
@@ -1,7 +1,10 @@
 apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
-  name: s3-upload-image
+  name: {{ include "name" }}-s3-upload-image
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
 spec:
   description: "Take all built images in the `source` workspace and uploads it to an S3 bucket using details provided in the `credentials` workspace"
   params: []

--- a/helm/capi-image-builder/templates/tasks/s3-upload-image.yaml
+++ b/helm/capi-image-builder/templates/tasks/s3-upload-image.yaml
@@ -1,0 +1,22 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: s3-upload-image
+spec:
+  description: "Take all built images in the `source` workspace and uploads it to an S3 bucket using details provided in the `credentials` workspace"
+  params: []
+  workspaces:
+  - name: credentials
+    mountPath: /root/.aws
+    optional: false
+  - name: source
+    optional: false
+  steps:
+    - name: upload-image
+      image: docker.io/amazon/aws-cli:2.0.52@sha256:1506cec98a7101c935176d440a14302ea528b8f92fcaf4a6f1ea2d7ecef7edc4 #tag: 2.0.52
+      script: |
+        set -x
+        files=($(find $(workspaces.source.path)))
+        for file in "${files[@]}"; do
+          aws s3 $(cat$(workspaces.credentials.path)/cli-params) cp ${file} s3://$(cat$(workspaces.credentials.path)/bucket-name)/
+        done

--- a/helm/capi-image-builder/templates/tasks/share-capg-images.yaml
+++ b/helm/capi-image-builder/templates/tasks/share-capg-images.yaml
@@ -1,7 +1,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
-  name: {{ include "name" }}-share-capg-images
+  name: {{ include "name" . }}-share-capg-images
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "labels.common" . | nindent 4 }}

--- a/helm/capi-image-builder/templates/tasks/share-capg-images.yaml
+++ b/helm/capi-image-builder/templates/tasks/share-capg-images.yaml
@@ -1,7 +1,10 @@
 apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
-  name: share-capg-images
+  name: {{ include "name" }}-share-capg-images
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
 spec:
   description: "Updates permissions of built images to share with all GCP accounts"
   params:

--- a/helm/capi-image-builder/templates/tasks/share-capg-images.yaml
+++ b/helm/capi-image-builder/templates/tasks/share-capg-images.yaml
@@ -10,12 +10,34 @@ spec:
   params:
   - name: KUBERNETES_VERSION
     type: string
+  - name: GCP_PROJECT_ID
+    type: string
+    default: giantswarm-vm-images
+  - name: IMAGE_NAME_PATTERN
+    type: string
+    default: cluster-api-ubuntu-[0-9]+-v${KUBE_VERSION}-gs
   workspaces:
   - name: credentials
     mountPath: /config/credentials
-    optional: true
+    optional: false
   steps:
     - name: share-images
-      image: bash:5 # TODO: Change this to something with gcloud
+      image: google/cloud-sdk:392.0.0
+      env:
+      - name: GCP_PROJECT_ID
+        value: $(params.GCP_PROJECT_ID)
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /config/credentials/sa.json
       script: |
-        # TODO: Find all images with provided Kube version and update IAM permissions
+        set -e
+
+        # Ensure we have the expected credentials file
+        test -f ${GOOGLE_APPLICATION_CREDENTIALS}
+
+        KUBE_VERSION=$(echo "$(params.KUBERNETES_VERSION)" | tr '.' '-')
+
+        IMAGES=$(gcloud compute images list --filter="name~'$(params.IMAGE_NAME_PATTERN)' AND selfLink~'.*/$(params.GCP_PROJECT_ID)/.*'" --format="value(name)")
+        for IMAGE in ${IMAGES}; do
+          echo "Sharing VM image ${IMAGE}"
+          gcloud compute images add-iam-policy-binding ${IMAGE} --member=allAuthenticatedUsers --role=roles/compute.imageUser
+        done

--- a/helm/capi-image-builder/templates/tasks/share-capg-images.yaml
+++ b/helm/capi-image-builder/templates/tasks/share-capg-images.yaml
@@ -1,0 +1,18 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: share-capg-images
+spec:
+  description: "Updates permissions of built images to share with all GCP accounts"
+  params:
+  - name: KUBERNETES_VERSION
+    type: string
+  workspaces:
+  - name: credentials
+    mountPath: /config/credentials
+    optional: true
+  steps:
+    - name: share-images
+      image: bash:5 # TODO: Change this to something with gcloud
+      script: |
+        # TODO: Find all images with provided Kube version and update IAM permissions

--- a/helm/capi-image-builder/templates/tasks/trigger-builds-from-kubernetes-releases.yaml
+++ b/helm/capi-image-builder/templates/tasks/trigger-builds-from-kubernetes-releases.yaml
@@ -1,0 +1,23 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: trigger-builds-from-kubernetes-releases
+spec:
+  description: "Fetches the latest Kubernetes releases, filtering out any pre-releases, and for all published since the provided `SINCE` seconds trigger a build pipeline"
+  params:
+  - name: SINCE
+    type: string
+    default: "93600" # 26 hours in seconds
+  steps:
+    - name: trigger-builds
+      image: bash:5
+      script: |
+        VERSIONS=($(curl --silent https://api.github.com/repos/kubernetes/kubernetes/releases | jq -r '. | map({tag_name,published_at,prerelease}) | .[] | select(.prerelease==false) | select(.published_at | strptime("%Y-%m-%dT%H:%M:%SZ")|mktime >= (now-$(params.SINCE))) | .tag_name'))
+
+        for v in "${VERSIONS[@]}"; do
+          echo "Triggering build for ${v}"
+          curl -X POST --silent \
+            http://el-build-capi-images-event-listener.{{.Release.Namespace}}.svc.cluster.local:8080 \
+            -H 'Content-Type: application/json' \
+            -d "{\"k8s\": { \"version\": \"${v#v}\" }}"
+        done

--- a/helm/capi-image-builder/templates/tasks/trigger-builds-from-kubernetes-releases.yaml
+++ b/helm/capi-image-builder/templates/tasks/trigger-builds-from-kubernetes-releases.yaml
@@ -1,7 +1,10 @@
 apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
-  name: trigger-builds-from-kubernetes-releases
+  name: {{ include "name" }}-trigger-builds-from-kubernetes-releases
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
 spec:
   description: "Fetches the latest Kubernetes releases, filtering out any pre-releases, and for all published since the provided `SINCE` seconds trigger a build pipeline"
   params:
@@ -17,7 +20,7 @@ spec:
         for v in "${VERSIONS[@]}"; do
           echo "Triggering build for ${v}"
           curl -X POST --silent \
-            http://el-build-capi-images-event-listener.{{.Release.Namespace}}.svc.cluster.local:8080 \
+            http://el-{{ include "name" }}-build-capi-images-event-listener.{{.Release.Namespace}}.svc.cluster.local:8080 \
             -H 'Content-Type: application/json' \
             -d "{\"k8s\": { \"version\": \"${v#v}\" }}"
         done

--- a/helm/capi-image-builder/templates/tasks/trigger-builds-from-kubernetes-releases.yaml
+++ b/helm/capi-image-builder/templates/tasks/trigger-builds-from-kubernetes-releases.yaml
@@ -1,7 +1,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
-  name: {{ include "name" }}-trigger-builds-from-kubernetes-releases
+  name: {{ include "name" . }}-trigger-builds-from-kubernetes-releases
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "labels.common" . | nindent 4 }}
@@ -20,7 +20,7 @@ spec:
         for v in "${VERSIONS[@]}"; do
           echo "Triggering build for ${v}"
           curl -X POST --silent \
-            http://el-{{ include "name" }}-build-capi-images-event-listener.{{.Release.Namespace}}.svc.cluster.local:8080 \
+            http://el-{{ include "name" . }}-build-capi-images-event-listener.{{.Release.Namespace}}.svc.cluster.local:8080 \
             -H 'Content-Type: application/json' \
             -d "{\"k8s\": { \"version\": \"${v#v}\" }}"
         done

--- a/helm/capi-image-builder/templates/triggers/capg.yaml
+++ b/helm/capi-image-builder/templates/triggers/capg.yaml
@@ -1,7 +1,10 @@
 apiVersion: triggers.tekton.dev/v1beta1
 kind: TriggerTemplate
 metadata:
-  name: capg-trigger-template
+  name: {{ include "name" }}-capg-trigger-template
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
 spec:
   params:
   - name: KUBERNETES_VERSION
@@ -16,12 +19,12 @@ spec:
         pipeline: "8h0m0s"
         tasks: "6h0m0s"
       pipelineRef:
-        name: build-capg-image
-      serviceAccountName: capi-builder
+        name: {{ include "name" }}-build-capg-image
+      serviceAccountName: {{ include "name" }}-capi-builder
       params:
       - name: KUBERNETES_VERSION
         value: $(tt.params.KUBERNETES_VERSION)
       workspaces:
       - name: credentials
         secret:
-          secretName: gcp-credentials
+          secretName: {{ include "name" }}-gcp-credentials

--- a/helm/capi-image-builder/templates/triggers/capg.yaml
+++ b/helm/capi-image-builder/templates/triggers/capg.yaml
@@ -1,7 +1,7 @@
 apiVersion: triggers.tekton.dev/v1beta1
 kind: TriggerTemplate
 metadata:
-  name: {{ include "name" }}-capg-trigger-template
+  name: {{ include "name" . }}-capg-trigger-template
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "labels.common" . | nindent 4 }}
@@ -19,12 +19,12 @@ spec:
         pipeline: "8h0m0s"
         tasks: "6h0m0s"
       pipelineRef:
-        name: {{ include "name" }}-build-capg-image
-      serviceAccountName: {{ include "name" }}-capi-builder
+        name: {{ include "name" . }}-build-capg-image
+      serviceAccountName: {{ include "name" . }}-capi-builder
       params:
       - name: KUBERNETES_VERSION
         value: $(tt.params.KUBERNETES_VERSION)
       workspaces:
       - name: credentials
         secret:
-          secretName: {{ include "name" }}-gcp-credentials
+          secretName: {{ include "name" . }}-gcp-credentials

--- a/helm/capi-image-builder/templates/triggers/capg.yaml
+++ b/helm/capi-image-builder/templates/triggers/capg.yaml
@@ -1,0 +1,27 @@
+apiVersion: triggers.tekton.dev/v1beta1
+kind: TriggerTemplate
+metadata:
+  name: capg-trigger-template
+spec:
+  params:
+  - name: KUBERNETES_VERSION
+    type: string
+  resourcetmplates:
+  - apiVersion: tekton.dev/v1beta1
+    kind: PipelineRun
+    metadata:
+      name: build-capg-image-$(tt.params.KUBERNETES_VERSION)
+    spec:
+      timeouts:
+        pipeline: "8h0m0s"
+        tasks: "6h0m0s"
+      pipelineRef:
+        name: build-capg-image
+      serviceAccountName: capi-builder
+      params:
+      - name: KUBERNETES_VERSION
+        value: $(tt.params.KUBERNETES_VERSION)
+      workspaces:
+      - name: credentials
+        secret:
+          secretName: gcp-credentials

--- a/helm/capi-image-builder/templates/triggers/capo.yaml
+++ b/helm/capi-image-builder/templates/triggers/capo.yaml
@@ -1,7 +1,10 @@
 apiVersion: triggers.tekton.dev/v1beta1
 kind: TriggerTemplate
 metadata:
-  name: capo-trigger-template
+  name: {{ include "name" }}-capo-trigger-template
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
 spec:
   params:
   - name: KUBERNETES_VERSION
@@ -16,15 +19,15 @@ spec:
         pipeline: "8h0m0s"
         tasks: "6h0m0s"
       pipelineRef:
-        name: build-capo-image
-      serviceAccountName: capi-builder
+        name: {{ include "name" }}-build-capo-image
+      serviceAccountName: {{ include "name" }}-capi-builder
       params:
       - name: KUBERNETES_VERSION
         value: $(tt.params.KUBERNETES_VERSION)
       workspaces:
       - name: credentials
         secret:
-          secretName: aws-credentials
+          secretName: {{ include "name" }}-aws-credentials
       - name: output
         volumeClaimTemplate:
           metadata:

--- a/helm/capi-image-builder/templates/triggers/capo.yaml
+++ b/helm/capi-image-builder/templates/triggers/capo.yaml
@@ -1,7 +1,7 @@
 apiVersion: triggers.tekton.dev/v1beta1
 kind: TriggerTemplate
 metadata:
-  name: {{ include "name" }}-capo-trigger-template
+  name: {{ include "name" . }}-capo-trigger-template
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "labels.common" . | nindent 4 }}
@@ -19,15 +19,15 @@ spec:
         pipeline: "8h0m0s"
         tasks: "6h0m0s"
       pipelineRef:
-        name: {{ include "name" }}-build-capo-image
-      serviceAccountName: {{ include "name" }}-capi-builder
+        name: {{ include "name" . }}-build-capo-image
+      serviceAccountName: {{ include "name" . }}-capi-builder
       params:
       - name: KUBERNETES_VERSION
         value: $(tt.params.KUBERNETES_VERSION)
       workspaces:
       - name: credentials
         secret:
-          secretName: {{ include "name" }}-aws-credentials
+          secretName: {{ include "name" . }}-aws-credentials
       - name: output
         volumeClaimTemplate:
           metadata:

--- a/helm/capi-image-builder/templates/triggers/capo.yaml
+++ b/helm/capi-image-builder/templates/triggers/capo.yaml
@@ -1,0 +1,37 @@
+apiVersion: triggers.tekton.dev/v1beta1
+kind: TriggerTemplate
+metadata:
+  name: capo-trigger-template
+spec:
+  params:
+  - name: KUBERNETES_VERSION
+    type: string
+  resourcetmplates:
+  - apiVersion: tekton.dev/v1beta1
+    kind: PipelineRun
+    metadata:
+      name: build-capo-image-$(tt.params.KUBERNETES_VERSION)
+    spec:
+      timeouts:
+        pipeline: "8h0m0s"
+        tasks: "6h0m0s"
+      pipelineRef:
+        name: build-capo-image
+      serviceAccountName: capi-builder
+      params:
+      - name: KUBERNETES_VERSION
+        value: $(tt.params.KUBERNETES_VERSION)
+      workspaces:
+      - name: credentials
+        secret:
+          secretName: aws-credentials
+      - name: output
+        volumeClaimTemplate:
+          metadata:
+            name: capo-output-$(tt.params.KUBERNETES_VERSION)
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 5Gi

--- a/helm/capi-image-builder/templates/triggers/check-kubernetes-versions.yaml
+++ b/helm/capi-image-builder/templates/triggers/check-kubernetes-versions.yaml
@@ -1,7 +1,7 @@
 apiVersion: triggers.tekton.dev/v1beta1
 kind: TriggerTemplate
 metadata:
-  name: {{ include "name" . }}-check-kubernetes-versions
+  name: {{ include "name" . }}-trigger-capi-builds
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "labels.common" . | nindent 4 }}

--- a/helm/capi-image-builder/templates/triggers/check-kubernetes-versions.yaml
+++ b/helm/capi-image-builder/templates/triggers/check-kubernetes-versions.yaml
@@ -1,7 +1,7 @@
 apiVersion: triggers.tekton.dev/v1beta1
 kind: TriggerTemplate
 metadata:
-  name: {{ include "name" }}-check-kubernetes-versions
+  name: {{ include "name" . }}-check-kubernetes-versions
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "labels.common" . | nindent 4 }}
@@ -14,5 +14,5 @@ spec:
       name: trigger-capi-builds
     spec:
       pipelineRef:
-        name: {{ include "name" }}-trigger-capi-builds
-      serviceAccountName: {{ include "name" }}-capi-builder
+        name: {{ include "name" . }}-trigger-capi-builds
+      serviceAccountName: {{ include "name" . }}-capi-builder

--- a/helm/capi-image-builder/templates/triggers/check-kubernetes-versions.yaml
+++ b/helm/capi-image-builder/templates/triggers/check-kubernetes-versions.yaml
@@ -1,7 +1,10 @@
 apiVersion: triggers.tekton.dev/v1beta1
 kind: TriggerTemplate
 metadata:
-  name: check-kubernetes-versions
+  name: {{ include "name" }}-check-kubernetes-versions
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
 spec:
   params: []
   resourcetmplates:
@@ -11,5 +14,5 @@ spec:
       name: trigger-capi-builds
     spec:
       pipelineRef:
-        name: trigger-capi-builds
-      serviceAccountName: capi-builder
+        name: {{ include "name" }}-trigger-capi-builds
+      serviceAccountName: {{ include "name" }}-capi-builder

--- a/helm/capi-image-builder/templates/triggers/check-kubernetes-versions.yaml
+++ b/helm/capi-image-builder/templates/triggers/check-kubernetes-versions.yaml
@@ -1,0 +1,15 @@
+apiVersion: triggers.tekton.dev/v1beta1
+kind: TriggerTemplate
+metadata:
+  name: check-kubernetes-versions
+spec:
+  params: []
+  resourcetmplates:
+  - apiVersion: tekton.dev/v1beta1
+    kind: PipelineRun
+    metadata:
+      name: trigger-capi-builds
+    spec:
+      pipelineRef:
+        name: trigger-capi-builds
+      serviceAccountName: capi-builder

--- a/helm/capi-image-builder/templates/triggers/cronjobs.yaml
+++ b/helm/capi-image-builder/templates/triggers/cronjobs.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: {{ include "name" . }}-trigger-capi-build-check
+  name: {{ include "name" . }}-trigger-capi-builds
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "labels.common" . | nindent 4 }}

--- a/helm/capi-image-builder/templates/triggers/cronjobs.yaml
+++ b/helm/capi-image-builder/templates/triggers/cronjobs.yaml
@@ -1,7 +1,10 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: trigger-capi-build-check
+  name: {{ include "name" }}-trigger-capi-build-check
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
 spec:
   schedule: "0 4 * * *"
   jobTemplate:
@@ -11,5 +14,5 @@ spec:
           containers:
           - name: trigger-capi-build-check
             image: curlimages/curl
-            args: ["curl", "-X", "POST", "--data", "{}", "el-trigger-capi-builds.{{.Release.Namespace}}.svc.cluster.local:8080"]
+            args: ["curl", "-X", "POST", "--data", "{}", "el-{{ include "name" }}-trigger-capi-builds.{{.Release.Namespace}}.svc.cluster.local:8080"]
           restartPolicy: OnFailure

--- a/helm/capi-image-builder/templates/triggers/cronjobs.yaml
+++ b/helm/capi-image-builder/templates/triggers/cronjobs.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: {{ include "name" }}-trigger-capi-build-check
+  name: {{ include "name" . }}-trigger-capi-build-check
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "labels.common" . | nindent 4 }}
@@ -14,5 +14,5 @@ spec:
           containers:
           - name: trigger-capi-build-check
             image: curlimages/curl
-            args: ["curl", "-X", "POST", "--data", "{}", "el-{{ include "name" }}-trigger-capi-builds.{{.Release.Namespace}}.svc.cluster.local:8080"]
+            args: ["curl", "-X", "POST", "--data", "{}", "el-{{ include "name" . }}-trigger-capi-builds.{{.Release.Namespace}}.svc.cluster.local:8080"]
           restartPolicy: OnFailure

--- a/helm/capi-image-builder/templates/triggers/cronjobs.yaml
+++ b/helm/capi-image-builder/templates/triggers/cronjobs.yaml
@@ -1,0 +1,15 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: trigger-capi-build-check
+spec:
+  schedule: "0 4 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: trigger-capi-build-check
+            image: curlimages/curl
+            args: ["curl", "-X", "POST", "--data", "{}", "el-trigger-capi-builds.{{.Release.Namespace}}.svc.cluster.local:8080"]
+          restartPolicy: OnFailure

--- a/helm/capi-image-builder/templates/triggers/event-listeners.yaml
+++ b/helm/capi-image-builder/templates/triggers/event-listeners.yaml
@@ -1,0 +1,40 @@
+apiVersion: triggers.tekton.dev/v1beta1
+kind: EventListener
+metadata:
+  name: build-capi-images-event-listener
+  annotations:
+    specific-provider-example-payload: |
+      {
+        "payload": "capg",
+        "k8s": { "version": "1.2.3" }
+      }
+    all-providers-example-payload: |
+      {
+        "k8s": { "version": "1.2.3" }
+      }
+spec:
+  serviceAccountName: tekton-triggers-sa
+  triggers:
+    - name: build-capg-image
+      interceptors:
+      - ref:
+          name: "cel"
+        params:
+        - name: "filter"
+          value: "has(body.provider) == false || body.provider == "capg""
+      bindings:
+      - ref: capi-trigger-template-binding
+      template:
+        ref: capg-trigger-template
+
+    - name: build-capo-image
+      interceptors:
+      - ref:
+          name: "cel"
+        params:
+        - name: "filter"
+          value: "has(body.provider) == false || body.provider == "capo""
+      bindings:
+      - ref: capi-trigger-template-binding
+      template:
+        ref: capo-trigger-template

--- a/helm/capi-image-builder/templates/triggers/event-listeners.yaml
+++ b/helm/capi-image-builder/templates/triggers/event-listeners.yaml
@@ -38,3 +38,16 @@ spec:
       - ref: capi-trigger-template-binding
       template:
         ref: capo-trigger-template
+
+---
+
+apiVersion: triggers.tekton.dev/v1beta1
+kind: EventListener
+metadata:
+  name: trigger-capi-builds
+spec:
+  serviceAccountName: tekton-triggers-sa
+  triggers:
+    - name: trigger-builds
+      template:
+        ref: check-kubernetes-versions

--- a/helm/capi-image-builder/templates/triggers/event-listeners.yaml
+++ b/helm/capi-image-builder/templates/triggers/event-listeners.yaml
@@ -1,7 +1,10 @@
 apiVersion: triggers.tekton.dev/v1beta1
 kind: EventListener
 metadata:
-  name: build-capi-images-event-listener
+  name: {{ include "name" }}-build-capi-images-event-listener
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
   annotations:
     specific-provider-example-payload: |
       {
@@ -13,7 +16,7 @@ metadata:
         "k8s": { "version": "1.2.3" }
       }
 spec:
-  serviceAccountName: tekton-triggers-sa
+  serviceAccountName: {{ include "name" }}-tekton-triggers-sa
   triggers:
     - name: build-capg-image
       interceptors:
@@ -23,9 +26,9 @@ spec:
         - name: "filter"
           value: "has(body.provider) == false || body.provider == "capg""
       bindings:
-      - ref: capi-trigger-template-binding
+      - ref: {{ include "name" }}-capi-trigger-template-binding
       template:
-        ref: capg-trigger-template
+        ref: {{ include "name" }}-capg-trigger-template
 
     - name: build-capo-image
       interceptors:
@@ -35,19 +38,22 @@ spec:
         - name: "filter"
           value: "has(body.provider) == false || body.provider == "capo""
       bindings:
-      - ref: capi-trigger-template-binding
+      - ref: {{ include "name" }}-capi-trigger-template-binding
       template:
-        ref: capo-trigger-template
+        ref: {{ include "name" }}-capo-trigger-template
 
 ---
 
 apiVersion: triggers.tekton.dev/v1beta1
 kind: EventListener
 metadata:
-  name: trigger-capi-builds
+  name: {{ include "name" }}-trigger-capi-builds
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
 spec:
-  serviceAccountName: tekton-triggers-sa
+  serviceAccountName: {{ include "name" }}-tekton-triggers-sa
   triggers:
     - name: trigger-builds
       template:
-        ref: check-kubernetes-versions
+        ref: {{ include "name" }}-check-kubernetes-versions

--- a/helm/capi-image-builder/templates/triggers/event-listeners.yaml
+++ b/helm/capi-image-builder/templates/triggers/event-listeners.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     specific-provider-example-payload: |
       {
-        "payload": "capg",
+        "provider": "capg",
         "k8s": { "version": "1.2.3" }
       }
     all-providers-example-payload: |
@@ -56,4 +56,4 @@ spec:
   triggers:
     - name: trigger-builds
       template:
-        ref: {{ include "name" . }}-check-kubernetes-versions
+        ref: {{ include "name" . }}-trigger-capi-builds

--- a/helm/capi-image-builder/templates/triggers/event-listeners.yaml
+++ b/helm/capi-image-builder/templates/triggers/event-listeners.yaml
@@ -1,7 +1,7 @@
 apiVersion: triggers.tekton.dev/v1beta1
 kind: EventListener
 metadata:
-  name: {{ include "name" }}-build-capi-images-event-listener
+  name: {{ include "name" . }}-build-capi-images-event-listener
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "labels.common" . | nindent 4 }}
@@ -16,7 +16,7 @@ metadata:
         "k8s": { "version": "1.2.3" }
       }
 spec:
-  serviceAccountName: {{ include "name" }}-tekton-triggers-sa
+  serviceAccountName: {{ include "name" . }}-tekton-triggers-sa
   triggers:
     - name: build-capg-image
       interceptors:
@@ -24,11 +24,11 @@ spec:
           name: "cel"
         params:
         - name: "filter"
-          value: "has(body.provider) == false || body.provider == "capg""
+          value: has(body.provider) == false || body.provider == "capg"
       bindings:
-      - ref: {{ include "name" }}-capi-trigger-template-binding
+      - ref: {{ include "name" . }}-capi-trigger-template-binding
       template:
-        ref: {{ include "name" }}-capg-trigger-template
+        ref: {{ include "name" . }}-capg-trigger-template
 
     - name: build-capo-image
       interceptors:
@@ -36,24 +36,24 @@ spec:
           name: "cel"
         params:
         - name: "filter"
-          value: "has(body.provider) == false || body.provider == "capo""
+          value: has(body.provider) == false || body.provider == "capo"
       bindings:
-      - ref: {{ include "name" }}-capi-trigger-template-binding
+      - ref: {{ include "name" . }}-capi-trigger-template-binding
       template:
-        ref: {{ include "name" }}-capo-trigger-template
+        ref: {{ include "name" . }}-capo-trigger-template
 
 ---
 
 apiVersion: triggers.tekton.dev/v1beta1
 kind: EventListener
 metadata:
-  name: {{ include "name" }}-trigger-capi-builds
+  name: {{ include "name" . }}-trigger-capi-builds
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "labels.common" . | nindent 4 }}
 spec:
-  serviceAccountName: {{ include "name" }}-tekton-triggers-sa
+  serviceAccountName: {{ include "name" . }}-tekton-triggers-sa
   triggers:
     - name: trigger-builds
       template:
-        ref: {{ include "name" }}-check-kubernetes-versions
+        ref: {{ include "name" . }}-check-kubernetes-versions

--- a/helm/capi-image-builder/templates/triggers/rbac.yaml
+++ b/helm/capi-image-builder/templates/triggers/rbac.yaml
@@ -1,24 +1,33 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: capi-builder
+  name: {{ include "name" }}-capi-builder
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
 
 ---
 
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: tekton-triggers-sa
+  name: {{ include "name" }}-tekton-triggers-sa
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
 
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: triggers-eventlistener-binding
+  name: {{ include "name" }}-triggers-eventlistener-binding
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
 subjects:
 - kind: ServiceAccount
-  name: tekton-triggers-sa
+  name: {{ include "name" }}-tekton-triggers-sa
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -29,11 +38,13 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: triggers-eventlistener-clusterbinding
+  name: {{ include "name" }}-triggers-eventlistener-clusterbinding
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
 subjects:
 - kind: ServiceAccount
-  name: tekton-triggers-sa
-  namespace: default
+  name: {{ include "name" }}-tekton-triggers-sa
+  namespace: {{.Release.Namespace}}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/helm/capi-image-builder/templates/triggers/rbac.yaml
+++ b/helm/capi-image-builder/templates/triggers/rbac.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "name" }}-capi-builder
+  name: {{ include "name" . }}-capi-builder
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "labels.common" . | nindent 4 }}
@@ -11,7 +11,7 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "name" }}-tekton-triggers-sa
+  name: {{ include "name" . }}-tekton-triggers-sa
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "labels.common" . | nindent 4 }}
@@ -21,13 +21,13 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ include "name" }}-triggers-eventlistener-binding
+  name: {{ include "name" . }}-triggers-eventlistener-binding
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "labels.common" . | nindent 4 }}
 subjects:
 - kind: ServiceAccount
-  name: {{ include "name" }}-tekton-triggers-sa
+  name: {{ include "name" . }}-tekton-triggers-sa
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -38,12 +38,12 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "name" }}-triggers-eventlistener-clusterbinding
+  name: {{ include "name" . }}-triggers-eventlistener-clusterbinding
   labels:
     {{- include "labels.common" . | nindent 4 }}
 subjects:
 - kind: ServiceAccount
-  name: {{ include "name" }}-tekton-triggers-sa
+  name: {{ include "name" . }}-tekton-triggers-sa
   namespace: {{.Release.Namespace}}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/helm/capi-image-builder/templates/triggers/rbac.yaml
+++ b/helm/capi-image-builder/templates/triggers/rbac.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: capi-builder
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tekton-triggers-sa
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: triggers-eventlistener-binding
+subjects:
+- kind: ServiceAccount
+  name: tekton-triggers-sa
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-triggers-eventlistener-roles
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: triggers-eventlistener-clusterbinding
+subjects:
+- kind: ServiceAccount
+  name: tekton-triggers-sa
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-triggers-eventlistener-clusterroles

--- a/helm/capi-image-builder/templates/triggers/trigger-binding.yaml
+++ b/helm/capi-image-builder/templates/triggers/trigger-binding.yaml
@@ -1,7 +1,7 @@
 apiVersion: triggers.tekton.dev/v1beta1
 kind: TriggerBinding
 metadata:
-  name: {{ include "name" }}-capi-trigger-template-binding
+  name: {{ include "name" . }}-capi-trigger-template-binding
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "labels.common" . | nindent 4 }}

--- a/helm/capi-image-builder/templates/triggers/trigger-binding.yaml
+++ b/helm/capi-image-builder/templates/triggers/trigger-binding.yaml
@@ -1,7 +1,10 @@
 apiVersion: triggers.tekton.dev/v1beta1
 kind: TriggerBinding
 metadata:
-  name: capi-trigger-template-binding
+  name: {{ include "name" }}-capi-trigger-template-binding
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
 spec:
   params:
   - name: KUBERNETES_VERSION

--- a/helm/capi-image-builder/templates/triggers/trigger-binding.yaml
+++ b/helm/capi-image-builder/templates/triggers/trigger-binding.yaml
@@ -1,0 +1,8 @@
+apiVersion: triggers.tekton.dev/v1beta1
+kind: TriggerBinding
+metadata:
+  name: capi-trigger-template-binding
+spec:
+  params:
+  - name: KUBERNETES_VERSION
+    value: $(body.k8s.version)

--- a/helm/capi-image-builder/values.schema.json
+++ b/helm/capi-image-builder/values.schema.json
@@ -1,0 +1,59 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "gcp": {
+            "type": "object",
+            "properties": {
+                "serviceAccountCredentialsJSON": {
+                    "type": "string"
+                }
+            }
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "registry": {
+                    "type": "string"
+                },
+                "tag": {
+                    "type": "string"
+                }
+            }
+        },
+        "project": {
+            "type": "object",
+            "properties": {
+                "branch": {
+                    "type": "string"
+                },
+                "commit": {
+                    "type": "string"
+                }
+            }
+        },
+        "s3": {
+            "type": "object",
+            "properties": {
+                "accessKeyId": {
+                    "type": "string"
+                },
+                "bucketName": {
+                    "type": "string"
+                },
+                "endpointURL": {
+                    "type": "string"
+                },
+                "secretAccessKey": {
+                    "type": "string"
+                }
+            }
+        },
+        "serviceType": {
+            "type": "string"
+        }
+    }
+}

--- a/helm/capi-image-builder/values.yaml
+++ b/helm/capi-image-builder/values.yaml
@@ -10,6 +10,10 @@ image:
   tag: 0.0.1
 
 s3:
+  image:
+    registry: docker.io
+    name: amazon/aws-cli
+    tag: 2.0.52@sha256:1506cec98a7101c935176d440a14302ea528b8f92fcaf4a6f1ea2d7ecef7edc4
   accessKeyId: ""
   secretAccessKey: ""
   endpointURL: ""

--- a/helm/capi-image-builder/values.yaml
+++ b/helm/capi-image-builder/values.yaml
@@ -1,4 +1,3 @@
-name: capi-image-builder
 serviceType: managed
 
 project:

--- a/helm/capi-image-builder/values.yaml
+++ b/helm/capi-image-builder/values.yaml
@@ -1,5 +1,3 @@
-# TEMPLATE-APP: This is set as a reasonable default, feel free to change.
-
 name: capi-image-builder
 serviceType: managed
 
@@ -7,8 +5,11 @@ project:
   branch: "[[ .Branch ]]"
   commit: "[[ .SHA ]]"
 
-image:
-  registry: quay.io
-  name: giantswarm/capi-image-builder
-  tag: v0.0.1
-  pullPolicy: IfNotPresent
+s3:
+  accessKeyId: ""
+  secretAccessKey: ""
+  endpointURL: ""
+  bucketName: ""
+
+gcp:
+  serviceAccountCredentialsJSON: ""

--- a/helm/capi-image-builder/values.yaml
+++ b/helm/capi-image-builder/values.yaml
@@ -4,6 +4,11 @@ project:
   branch: "[[ .Branch ]]"
   commit: "[[ .SHA ]]"
 
+image:
+  registry: quay.io
+  name: giantswarm/capi-image-builder
+  tag: 0.0.1
+
 s3:
   accessKeyId: ""
   secretAccessKey: ""


### PR DESCRIPTION
Based on discussion in https://github.com/giantswarm/giantswarm/issues/22713

Currently implements:
* CAPI image building for **CAPO** and **CAPG** images
* Check for existing **CAPO** images prior to building
* Uploading of **CAPO** images to S3
* Event listener and trigger templates for both CAPO and CAPG pipelines. Currently set up to be able to trigger all providers or a specific provider based on payload.
* Build trigger pipeline that checks for new Kubernetes releases and triggers the build pipelines from any found in the past 26 hours.
* CronJob to trigger the build trigger pipeline every day
* sha256sum generation of any local files generated (e.g. for CAPO images)
* Share **CAPG** images with all GCP accounts post-build