### PR TITLE
Correctly reference emptyDir in trigger templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Reference `emptyDir` correctly in TriggerTemplate rather than Pipeline
+
 ## [1.0.8] - 2022-07-20
 
 ### Fixed

--- a/helm/capi-image-builder/templates/pipelines/capg.yaml
+++ b/helm/capi-image-builder/templates/pipelines/capg.yaml
@@ -15,6 +15,12 @@ spec:
   - name: credentials
     description: "GCP credentials containing the required `sa.json` file for authenticating"
     optional: false
+  - name: vars
+    description: "Shared workspace for passing vars betweeen task steps"
+    optional: false
+  - name: output
+    description: "The location where VM images are saved to"
+    optional: false
   tasks:
     - name: build-capi-image
       timeout: 6h
@@ -34,9 +40,9 @@ spec:
       - name: credentials
         workspace: credentials
       - name: output
-        emptyDir: {}
+        workspace: output
       - name: vars
-        emptyDir: {}
+        workspace: vars
 
     - name: share-images
       taskRef:

--- a/helm/capi-image-builder/templates/pipelines/capo.yaml
+++ b/helm/capi-image-builder/templates/pipelines/capo.yaml
@@ -10,11 +10,14 @@ spec:
   - name: KUBERNETES_VERSION
     type: string
   workspaces:
-  - name: output
-    description: "The location where VM images are saved to"
-    optional: false
   - name: credentials
     description: "The AWS S3 credentials and details needed to upload built images to an S3 bucket"
+    optional: false
+  - name: vars
+    description: "Shared workspace for passing vars betweeen task steps"
+    optional: false
+  - name: output
+    description: "The location where VM images are saved to"
     optional: false
   tasks:
     - name: check-image-exists
@@ -51,7 +54,7 @@ spec:
       - name: output
         workspace: output
       - name: vars
-        emptyDir: {}
+        workspace: vars
 
     - name: upload-images
       taskRef:

--- a/helm/capi-image-builder/templates/triggers/capg.yaml
+++ b/helm/capi-image-builder/templates/triggers/capg.yaml
@@ -27,3 +27,7 @@ spec:
       - name: credentials
         secret:
           secretName: {{ include "name" . }}-gcp-credentials
+      - name: vars
+        emptyDir: {}
+      - name: output
+        emptyDir: {}

--- a/helm/capi-image-builder/templates/triggers/capo.yaml
+++ b/helm/capi-image-builder/templates/triggers/capo.yaml
@@ -37,3 +37,5 @@ spec:
             resources:
               requests:
                 storage: 5Gi
+      - name: vars
+        emptyDir: {}


### PR DESCRIPTION
Not sure why these `Pipelines` didn't error when creating but looks like volume definitions are only in `PipelineRuns` (as created by `TriggerTemplates`