### PR TITLE
Refactor output directory logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Configure the built VM image name
 - Enable debug packer log on rety of build task
+- OS_STRING param to CAPO pipeline to easily change VM base OS
+
+### Changed
+
+- Don't override the default output directory and instead symlink the expected location to our workspace
 
 ## [1.0.13] - 2022-07-21
 

--- a/helm/capi-image-builder/templates/pipelines/capo.yaml
+++ b/helm/capi-image-builder/templates/pipelines/capo.yaml
@@ -9,6 +9,9 @@ spec:
   params:
   - name: KUBERNETES_VERSION
     type: string
+  - name: OS_STRING
+    type: string
+    default: "ubuntu-2004"
   workspaces:
   - name: credentials
     description: "The AWS S3 credentials and details needed to upload built images to an S3 bucket"
@@ -26,7 +29,7 @@ spec:
       params:
       - name: IMAGE
         # We pass the sha256 rather than the image itself so we can check that the process completed (sha is the last setp)
-        value: ubuntu-2004-kube-v$(params.KUBERNETES_VERSION)/ubuntu-2004-kube-v$(params.KUBERNETES_VERSION).sha256sums
+        value: $(params.OS_STRING)-kube-v$(params.KUBERNETES_VERSION)/$(params.OS_STRING)-kube-v$(params.KUBERNETES_VERSION).sha256sums
       workspaces:
       - name: credentials
         workspace: credentials
@@ -46,9 +49,7 @@ spec:
         - name: KUBERNETES_VERSION
           value: $(params.KUBERNETES_VERSION)
         - name: MAKE_TARGET
-          value: "build-qemu-ubuntu-2004"
-        - name: IMAGE_NAME
-          value: ubuntu-2004-kube-v$(params.KUBERNETES_VERSION)
+          value: "build-qemu-$(params.OS_STRING)"
         - name: PACKER_VARS_FILE
           value: |
             {"memory": "4096","cpus": "4","accelerator": "none","disk_compression": "true","disk_discard": "unmap"}

--- a/helm/capi-image-builder/templates/tasks/build-capi-image.yaml
+++ b/helm/capi-image-builder/templates/tasks/build-capi-image.yaml
@@ -78,7 +78,7 @@ spec:
         set -e
         source $(workspaces.vars.path)/env
 
-        # Symlink the `./output` directory to our output workspace
+        # Symlink the `./output` directory to our output workspace (instead of using `mv` after built as it would be slower to copy the image across)
         ln -s $(workspaces.output.path) ./output
 
         make $(params.MAKE_TARGET)

--- a/helm/capi-image-builder/templates/tasks/build-capi-image.yaml
+++ b/helm/capi-image-builder/templates/tasks/build-capi-image.yaml
@@ -23,9 +23,6 @@ spec:
   - name: PACKER_VARS_FILE
     type: string
     default: "{}"
-  - name: IMAGE_NAME
-    type: string
-    default: "cluster-api-v$(params.KUBERNETES_VERSION)"
   workspaces:
   - name: credentials
     mountPath: /config/credentials
@@ -49,8 +46,7 @@ spec:
           "kubernetes_deb_version": "$(params.KUBERNETES_VERSION)-00",
           "kubernetes_rpm_version": "$(params.KUBERNETES_VERSION)-0",
           "kubernetes_semver": "v$(params.KUBERNETES_VERSION)",
-          "kubernetes_series": "v${VERSION_MAJOR}.${VERSION_MINOR}",
-          "output_directory": "$(workspaces.output.path)/$(params.IMAGE_NAME)"
+          "kubernetes_series": "v${VERSION_MAJOR}.${VERSION_MINOR}"
         }
         END
         echo "Default Packer vars:"
@@ -64,10 +60,7 @@ spec:
         echo "Final Packer vars:"
         cat $(workspaces.vars.path)/vars.json
 
-    - name: build-env-vars
-      image: bash:5
-      script: |
-        #!/usr/bin/env bash
+        # Populate env vars file
         echo "$(params.ENV_VARS)" > $(workspaces.vars.path)/env
 
     - name: build-image
@@ -85,9 +78,13 @@ spec:
         set -e
         source $(workspaces.vars.path)/env
 
+        # Symlink the `./output` directory to our output workspace
+        ln -s $(workspaces.output.path) ./output
+
         make $(params.MAKE_TARGET)
 
         # If a local file has been created (e.g. for CAPO) we'll also generate a sha256 for it
-        if [ -f "$(workspaces.output.path)/$(params.IMAGE_NAME)" ]; then
-          sha256sum $(workspaces.output.path)/$(params.IMAGE_NAME) > $(workspaces.output.path)/$(params.IMAGE_NAME).sha256sums
-        fi
+        for file in $(find -f "$(workspaces.output.path)/*")
+        do
+          sha256sum ${file} > ${file}.sha256sums
+        done

--- a/helm/capi-image-builder/templates/tasks/build-capi-image.yaml
+++ b/helm/capi-image-builder/templates/tasks/build-capi-image.yaml
@@ -84,7 +84,7 @@ spec:
         make $(params.MAKE_TARGET)
 
         # If a local file has been created (e.g. for CAPO) we'll also generate a sha256 for it
-        for file in $(find -f "$(workspaces.output.path)/*")
+        for file in $(find "$(workspaces.output.path)/" -type f)
         do
           sha256sum ${file} > ${file}.sha256sums
         done


### PR DESCRIPTION
The output_directory var is only used when creating images locally (e.g. for CAPO) and the default naming structure is desirable in those cases so no point overriding it. Instead we ensure the expected output location is symlinked to our workspace PVC.